### PR TITLE
Save the alt text along with the file

### DIFF
--- a/Source/WebExtension/background.js
+++ b/Source/WebExtension/background.js
@@ -1,5 +1,5 @@
-/**                                                                                
- * Returns a handler which will open a new window when activated.                  
+/**
+ * Returns a handler which will open a new window when activated.
  */
 function getClickHandler() {
     return function(info, tab) {
@@ -8,19 +8,20 @@ function getClickHandler() {
             path_array = source_url.split('/');
             source_url = path_array[0] + "//" + path_array[2];
         }
-        chrome.windows.create({
-            "url": "https://mltshp.com/tools/p?url=" + escape(info.srcUrl) + "&source_url=" + escape(source_url),
-            "type": 'popup',
-            "height": 650,
-            "width": 850,
-            "top": (screen.height / 2) - (650 / 2),
-            "left": (screen.width / 2) - (850 / 2)
+        chrome.tabs.sendMessage(tab.id, "getAltText", { frameId: info.frameId }, data => {
+            chrome.windows.create({
+                "url": "https://mltshp.com/tools/p?url=" + escape(info.srcUrl) + "&source_url=" + escape(source_url) + '&alt=' + escape(data.alt),
+                "type": 'popup',
+                "height": 650,
+                "width": 850,
+                "top": (screen.height / 2) - (650 / 2),
+                "left": (screen.width / 2) - (850 / 2)
+            });
         });
-
     };
 };
-/**                                                                                
- * Create a context menu which will only show up for images.                       
+/**
+ * Create a context menu which will only show up for images.
  */
 chrome.contextMenus.create({
     "title": "Save this image on MLTSHP",

--- a/Source/WebExtension/content.js
+++ b/Source/WebExtension/content.js
@@ -1,0 +1,13 @@
+var clickedEl = null;
+
+document.addEventListener("contextmenu", function(event){
+    clickedEl = event.target;
+}, true);
+
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+    if (request == "getAltText") {
+        sendResponse({
+            alt: clickedEl.getAttribute('alt') || ''
+        });
+    }
+});

--- a/Source/WebExtension/manifest.json
+++ b/Source/WebExtension/manifest.json
@@ -14,6 +14,12 @@
         "96": "icon_96.png",
         "128": "icon_128.png"
     },
+    "content_scripts": [
+        {
+          "matches": ["*://*/*"],
+          "js": ["content.js"]
+        }
+    ],
     "background": {
         "page": "background.html"
     },


### PR DESCRIPTION
This PR makes it so that the context menu to "Save this image on MLTSHP" will grab any existing alt text that's present on the page, carrying it over to the alt text field in the picker form.