### PR TITLE
escape() -> encodeURIComponent()

### DIFF
--- a/Source/Legacy/mltshp.firefox/chrome/content/overlay.js
+++ b/Source/Legacy/mltshp.firefox/chrome/content/overlay.js
@@ -25,10 +25,10 @@ var mltshp = {
         }
 
         if (source_url) {
-            source_query = "&source_url=" + escape(source_url);
+            source_query = "&source_url=" + encodeURIComponent(source_url);
         }
 
-        window.open(mltshp.mltshpurl + escape(image_url) + source_query, "Save an image.", "toolbar=yes,location=yes,directories=yes,status=yes,menubar=yes,scrollbars=yes,copyhistory=yes,resizable=yes");
+        window.open(mltshp.mltshpurl + encodeURIComponent(image_url) + source_query, "Save an image.", "toolbar=yes,location=yes,directories=yes,status=yes,menubar=yes,scrollbars=yes,copyhistory=yes,resizable=yes");
     },
 };
 

--- a/Source/WebExtension/background.js
+++ b/Source/WebExtension/background.js
@@ -10,7 +10,7 @@ function getClickHandler() {
         }
         chrome.tabs.sendMessage(tab.id, "getAltText", { frameId: info.frameId }, data => {
             chrome.windows.create({
-                "url": "https://mltshp.com/tools/p?url=" + escape(info.srcUrl) + "&source_url=" + escape(source_url) + '&alt=' + escape(data.alt),
+                "url": "https://mltshp.com/tools/p?url=" + encodeURIComponent(info.srcUrl) + "&source_url=" + encodeURIComponent(source_url) + '&alt=' + encodeURIComponent(data.alt),
                 "type": 'popup',
                 "height": 650,
                 "width": 850,


### PR DESCRIPTION
Fixes a character encoding problem where UTF-8 escaped characters are expected but we pass Latin-1.

E.g., `https://mltshp.com/tools/p?url=[url]&source_url=[src]&alt=%B3` instead of `https://mltshp.com/tools/p?url=[url]&source_url=[src]&alt=%C2%B3` when the alt text should be `³`.